### PR TITLE
Fix QueryBuilder memory leak

### DIFF
--- a/DataFetcher.hpp
+++ b/DataFetcher.hpp
@@ -39,8 +39,8 @@ public:
 
     void MakeQuery(const QString& tickerSymbol) const
     {
-        QueryBuilder& queryBuilder = QueryBuilder::create()
-        .setAnalyticsUrl(sourceUrl)
+        QueryBuilder queryBuilder = QueryBuilder::create()
+            .setAnalyticsUrl(sourceUrl)
             .setFunction(function)
             .setTickerSymbol(tickerSymbol)
             .setApiKey(apiKey);

--- a/QueryBuilder.hpp
+++ b/QueryBuilder.hpp
@@ -7,10 +7,9 @@
 class QueryBuilder
 {
 public:
-    static QueryBuilder& create()
+    static QueryBuilder create()
     {
-        QueryBuilder* queryBuilder = new QueryBuilder();
-        return *queryBuilder;
+        return QueryBuilder();
     }
 
     QueryBuilder& setApiKey(const QString& apiKey)
@@ -52,10 +51,10 @@ public:
 
 private:
     QueryBuilder() = default;
-    QueryBuilder(const QueryBuilder&) = delete;
-    QueryBuilder(QueryBuilder&&) = delete;
-    QueryBuilder& operator=(const QueryBuilder&) = delete;
-    QueryBuilder&& operator=(QueryBuilder&&) = delete;
+    QueryBuilder(const QueryBuilder&) = default;
+    QueryBuilder(QueryBuilder&&) = default;
+    QueryBuilder& operator=(const QueryBuilder&) = default;
+    QueryBuilder& operator=(QueryBuilder&&) = default;
 
     QString apiKey;
     QString analyticsUrl;


### PR DESCRIPTION
## Summary
- return QueryBuilder by value instead of leaking heap memory
- update DataFetcher usage of QueryBuilder
- enable default copy/move operations for QueryBuilder

## Testing
- `python3 -m py_compile python/*.py`
- `cmake -B build -S .` *(fails: Could not find a package configuration file provided by "QT")*